### PR TITLE
Restyled HUD to match redesigns

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,8 @@ var setup = state.current();
 function renderHolder() {
     if (document.readyState === 'complete') {
         var url = util.resolveClientUrl(util.currentRequestId(), true);
-        var html = '<div class="glimpse"><a class="glimpse-icon" target="_glimpse" href="' + url + '"><div class="glimpse-icon-text">Glimpse</div></a><div class="glimpse-hud"></div></div>'
+        var arrow = '<svg class="glimpse-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2048 2048"><title>E143_GoLegacy</title><path d="M1022,2H2046V1026H1918V221L91,2047,1,1957,1827,130H1022V2Z"/></svg>';
+        var html = '<a target="_glimpse" href="' + url + '" class="glimpse"><div class="glimpse-link">' + arrow + '<span class="glimpse-link-text">View full Glimpse</span></div><div class="glimpse-hud"></div></a>'
         var body = $('body');
         var htmlElement
         $(html).appendTo('body');

--- a/src/index.scss
+++ b/src/index.scss
@@ -104,14 +104,6 @@ $hud-height: 40px;
 }
 .glimpse .glimpse-hud-title { 
     display: none;
-    // position: absolute;
-    // color: white;
-    // text-transform: uppercase; 
-    // cursor: pointer;
-    // font-weight: bold;
-    // height: 100%;
-    // width: 12px;
-    // left: -12px;
 }
 .glimpse .glimpse-hud-title span { 
     position: absolute;
@@ -153,7 +145,6 @@ $hud-height: 40px;
 }
 .glimpse .glimpse-hud-data {
     transition: color 0.3s ease;
-    margin-right: 1ch;
 }
 .glimpse .glimpse-hud-data-important {
     font-size: 1.2em;

--- a/src/index.scss
+++ b/src/index.scss
@@ -24,10 +24,40 @@
     bottom: 0;
     float: right;
     position: fixed;
-    min-width: 1370px;
     transform: translatez(0);
     z-index: 100000;
     height: 36px;
+}
+.glimpse .glimpse-link {
+    display: block;
+    height: 100%;
+    float: left;
+    line-height: 36px;
+    padding: 0 1rem;
+    background-color: #3c454f;
+    border-right: 1px solid #3399ff;
+
+    &:hover {
+        background-color: rgba(#0d5c9d, 0.85);
+
+        > .glimpse-link-text {
+            color: #f1f1f1;
+        }
+        > .glimpse-arrow {
+            color: #f1f1f1;
+        }
+    }
+}
+.glimpse .glimpse-link-text {
+    vertical-align: middle;
+    color: #3399ff;
+}
+.glimpse .glimpse-arrow {
+    width: 1rem;
+    margin-right: 1rem;
+    display: inline-block;
+    vertical-align: middle;
+    fill: #3399ff;
 }
 .glimpse td, .glimpse span, .glimpse div, .glimpse th {
     color: #fff;
@@ -59,30 +89,29 @@
     margin-top: 25px;
 }
 
-
-
 .glimpse .glimpse-hud { 
     padding: 0 5px 0 0;
-    float: right; 
+    display: inline-block;
     background-color: #3c454f;
 }
 .glimpse .glimpse-hud-section {
     float: left; 
     transition: all 0.3s ease;
-    border-left: 11px solid #71b1d1;
+    border: none;
     position: relative;
     cursor: default;
     height: 37px;
 }
 .glimpse .glimpse-hud-title { 
-    position: absolute;
-    color: white;
-    text-transform: uppercase; 
-    cursor: pointer;
-    font-weight: bold;
-    height: 100%;
-    width: 12px;
-    left: -12px;
+    display: none;
+    // position: absolute;
+    // color: white;
+    // text-transform: uppercase; 
+    // cursor: pointer;
+    // font-weight: bold;
+    // height: 100%;
+    // width: 12px;
+    // left: -12px;
 }
 .glimpse .glimpse-hud-title span { 
     position: absolute;

--- a/src/index.scss
+++ b/src/index.scss
@@ -9,6 +9,8 @@
          url('~/glimpse/hud/assets/selawkl.woff') format('woff');
 }
 
+$hud-height: 40px;
+
 .glimpse, .glimpse *, .glimpse a, .glimpse td, .glimpse th, .glimpse table {
     font-family: 'Segoe UI', 'Selawik', Tahoma, Geneva, Verdana, sans-serif;
     background-color: transparent;
@@ -26,15 +28,15 @@
     position: fixed;
     transform: translatez(0);
     z-index: 100000;
-    height: 36px;
+    height: $hud-height;
+    background-color: rgba(black, 0.85);
 }
 .glimpse .glimpse-link {
     display: block;
     height: 100%;
     float: left;
-    line-height: 36px;
+    line-height: $hud-height;
     padding: 0 1rem;
-    background-color: #3c454f;
     border-right: 1px solid #3399ff;
 
     &:hover {
@@ -44,7 +46,7 @@
             color: #f1f1f1;
         }
         > .glimpse-arrow {
-            color: #f1f1f1;
+            fill: #f1f1f1;
         }
     }
 }
@@ -71,7 +73,6 @@
     width: 100%;
 }
 .glimpse .glimpse-icon {
-    background-color: #3c454f;
     margin: 0;
     padding: 0 8px;
     float: right;
@@ -79,11 +80,10 @@
     background-image: url(~/glimpse/hud/assets/glimpse-logo.png);
     background-repeat: no-repeat;
     background-size: 47px 37px;
-    height: 36px;
+    height: $hud-height;
 }
 .glimpse .glimpse-icon-text {
     font-size: 5px;
-    color: #3c454f;
     transform: rotate(270deg);
     margin-left: 45px;
     margin-top: 25px;
@@ -92,7 +92,7 @@
 .glimpse .glimpse-hud { 
     padding: 0 5px 0 0;
     display: inline-block;
-    background-color: #3c454f;
+    height: $hud-height;
 }
 .glimpse .glimpse-hud-section {
     float: left; 
@@ -153,6 +153,7 @@
 }
 .glimpse .glimpse-hud-data {
     transition: color 0.3s ease;
+    margin-right: 1ch;
 }
 .glimpse .glimpse-hud-data-important {
     font-size: 1.2em;
@@ -192,35 +193,33 @@
     margin-left: 5px;
 }
 .glimpse .glimpse-hud-value {
-    font-size: 1em;
-    line-height: 100%;
-    margin-top: -3px;
+    font-size: 16px;
+    line-height: $hud-height;
+    display: inline-block;
 }
 @media screen\0 {   
     .glimpse .glimpse-hud-value { margin-top: -4px; }
     .glimpse .glimpse-hud-detail-normal .glimpse-hud-header { margin-bottom: 2px; }
 } 
 .glimpse .glimpse-hud-header { 
-    opacity: 0.6;
-    font-size: 0.7em;
+    font-size: 13px;
     line-height: 100%;
     white-space: nowrap;
+    display: inline-block;
+    color: #999;
+    margin-right: 1ch;
 }
 .glimpse .glimpse-hud-detail-extra-large .glimpse-hud-header {
     font-size: 0.5em;
 }
-.glimpse .glimpse-hud-detail-large .glimpse-hud-header {
-    font-size: 0.6em;
-}
 .glimpse .glimpse-hud-detail-normal.glimpse-hud-detail-position-top .glimpse-hud-header {
     padding-bottom: 2px;
 }
-.glimpse .glimpse-hud-prefix, .glimpse .glimpse-hud-postfix, .glimpse .glimpse-hud-spacer, .glimpse .glimpse-hud-plain { 
-    opacity: 0.4;
-    font-size: 0.9em;
-}
 .glimpse .glimpse-hud-postfix {
     padding-left: 2px;
+    color: #999;
+    font-size: 13px;
+    margin-left: 1ch;
 }
 .glimpse .glimpse-hud-prefix {
     padding-right: 2px;
@@ -249,7 +248,6 @@
     transition: max-height 0.3s ease 0.3s;
 }
 .glimpse .glimpse-hud-popup {
-    background-color: #3c454f;
     border-left: 11px solid #71b1d1;
     position: absolute;
     left: -11px;

--- a/src/sections/section-http.js
+++ b/src/sections/section-http.js
@@ -11,7 +11,7 @@ var structure = {
     title: 'HTTP',
     id: 'http',
     color: '#e2875e',
-    xpopup: {
+    popup: {
         render: function(details) {
             var requestDetails = details.request.data,
                 html = '<div class="glimpse-hud-popup-header">Browser Request</div>';
@@ -34,6 +34,8 @@ var structure = {
     layout: {
         mini: {
             request: {},
+
+            // Not visible in current design:
             // wire: {},
             // server: {},
             // client: {}

--- a/src/sections/section-http.js
+++ b/src/sections/section-http.js
@@ -24,7 +24,7 @@ var structure = {
         }
     },
     defaults: {
-        request: { title: 'Request', description: 'Total request time from click to dom ready', visible: true, size: 1, position: 0, align: 0, postfix: 'ms', getData: function(details) { return details.request.data.total.duration; }, id: 'glimpse-hud-data-request' },
+        request: { title: 'Total Time', description: 'Total request time from click to dom ready', visible: true, size: 1, position: 0, align: 0, postfix: 'ms', getData: function(details) { return details.request.data.total.duration; }, id: 'glimpse-hud-data-request' },
         wire: { title: 'Network', description: 'Total time on the network', visible: true, size: 2, position: 0, align: 0, postfix: 'ms', getData: function(details) { var duration = details.request.data.network.duration; return duration === null ? '...' : duration; }, id: 'glimpse-hud-data-network' },
         server: { title: 'Server', description: 'Total time on the server', visible: true, size: 2, position: 0, align: 0, postfix: 'ms', getData: function(details) { return details.request.data.server.duration; }, id: 'glimpse-hud-data-server' },
         client: { title: 'Client', description: 'Total time in browser (to load)', visible: true, size: 2, position: 0, align: 0, postfix: 'ms', getData: function(details) { var duration = details.request.data.browser.duration; return duration === null ? '...' : duration; }, id: 'glimpse-hud-data-client' }, 
@@ -34,9 +34,9 @@ var structure = {
     layout: {
         mini: {
             request: {},
-            wire: {},
-            server: {},
-            client: {}
+            // wire: {},
+            // server: {},
+            // client: {}
         },
         popup: {
             request: { title: 'Total Request Time', size: 0, position: 1, align: 1 },

--- a/src/sections/section-http.js
+++ b/src/sections/section-http.js
@@ -11,7 +11,7 @@ var structure = {
     title: 'HTTP',
     id: 'http',
     color: '#e2875e',
-    popup: {
+    xpopup: {
         render: function(details) {
             var requestDetails = details.request.data,
                 html = '<div class="glimpse-hud-popup-header">Browser Request</div>';

--- a/src/sections/section.js
+++ b/src/sections/section.js
@@ -28,5 +28,5 @@ module.exports = {
 
 // TODO: Need to come up with a better self registration process
 require('./section-http');
-require('./section-host');
-require('./section-ajax');
+// require('./section-host');
+// require('./section-ajax');

--- a/src/sections/section.js
+++ b/src/sections/section.js
@@ -28,5 +28,7 @@ module.exports = {
 
 // TODO: Need to come up with a better self registration process
 require('./section-http');
+
+// Not visible in current design:
 // require('./section-host');
 // require('./section-ajax');

--- a/src/sections/util/rendering.js
+++ b/src/sections/util/rendering.js
@@ -26,6 +26,7 @@ var section = function(structure, details, opened) {
     }
     html += '</div>';
 
+    // Popups temporarily disabled
     // if (!structure.popup.suppress) { html += popup(structure, details); }
 
     return html + '</div>';

--- a/src/sections/util/rendering.js
+++ b/src/sections/util/rendering.js
@@ -26,7 +26,7 @@ var section = function(structure, details, opened) {
     }
     html += '</div>';
 
-    if (!structure.popup.suppress) { html += popup(structure, details); }
+    // if (!structure.popup.suppress) { html += popup(structure, details); }
 
     return html + '</div>';
 };


### PR DESCRIPTION
For #17: https://github.com/Glimpse/Glimpse.Design/blob/master/%5BLatest%5D%20HUD.md

- Added styles to match existing structure with designs
- Commented out some irrelevant parts that are not visible in the updated designs
- Added a link to Glimpse (per the design)
- Disabled popup views
- (WIP) Blurred background
<img width="371" alt="screen shot 2017-02-16 at 3 03 10 pm" src="https://cloud.githubusercontent.com/assets/1093738/23038736/1af82e74-f459-11e6-8f72-4513f09dbb59.png">
<img width="368" alt="screen shot 2017-02-16 at 3 03 20 pm" src="https://cloud.githubusercontent.com/assets/1093738/23038735/1af709d6-f459-11e6-8ee7-cbb675718363.png">
