### PR TITLE
Using url-template library to expand template URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "webpack": "1.12.2"
   },
   "dependencies": {
-    "jquery": "2.1.4"
+    "jquery": "2.1.4",
+    "url-template": "^2.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
   },
   "dependencies": {
     "jquery": "2.1.4",
-    "url-template": "^2.0.8"
+    "uri-templates": "^0.2.0"
   }
 }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var $ = require('$jquery');
-var template = require('url-template');
+var UriTemplate = require('uri-templates');
 
 var camelCaseRegEx = /^([A-Z])|[\s-_](\w)/g;
 var usedMessageTypes = function() {
@@ -28,9 +28,9 @@ module.exports = {
         return hudScriptElement.getAttribute('data-request-id');
     },
     resolveClientUrl: function(requestId, follow) {
-        var clientTemplate = template.parse(hudScriptElement.getAttribute('data-client-template'));
+        var clientTemplate = new UriTemplate(hudScriptElement.getAttribute('data-client-template'));
 
-        return clientTemplate.expand({
+        return clientTemplate.fill({
             requestId: requestId,
             follow: !!follow,
             metadataUri: encodeURIComponent(hudScriptElement.getAttribute('data-metadata-template')),

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -32,7 +32,7 @@ module.exports = {
 
         return clientTemplate.fill({
             requestId: requestId,
-            follow: !!follow,
+            follow: follow,
             metadataUri: encodeURIComponent(hudScriptElement.getAttribute('data-metadata-template')),
         });
     },

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -49,6 +49,6 @@ module.exports = {
                 (uri.substring(uri.indexOf('//') + 2, uri.length) + '/').indexOf(window.location.host + '/') == 0);
     },
     htmlEncode: function (value) {
-        return (value !== null) ? value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;') : '';
+        return (value != null) ? value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;') : '';
     }
 };

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -49,6 +49,6 @@ module.exports = {
                 (uri.substring(uri.indexOf('//') + 2, uri.length) + '/').indexOf(window.location.host + '/') == 0);
     },
     htmlEncode: function (value) {
-        return !(value == null) ? value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;') : '';
+        return (value !== null) ? value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;') : '';
     }
 };

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var $ = require('$jquery');
+var template = require('url-template');
 
 var camelCaseRegEx = /^([A-Z])|[\s-_](\w)/g;
 var usedMessageTypes = function() {
@@ -27,13 +28,13 @@ module.exports = {
         return hudScriptElement.getAttribute('data-request-id');
     },
     resolveClientUrl: function(requestId, follow) {
-        var clientTemplate = hudScriptElement.getAttribute('data-client-template');
+        var clientTemplate = template.parse(hudScriptElement.getAttribute('data-client-template'));
 
-        var params = '&requestId=' + requestId;
-        params += '&metadataUri=' + encodeURIComponent(hudScriptElement.getAttribute('data-metadata-template')); // This happens to be fully resolved already
-        params += follow ? '&follow=true' : '';
-
-        return clientTemplate.replace('{&requestId,follow,metadataUri}', params); // TODO: This should probably be resolved with a URI Template library
+        return clientTemplate.expand({
+            requestId: requestId,
+            follow: !!follow,
+            metadataUri: encodeURIComponent(hudScriptElement.getAttribute('data-metadata-template')),
+        });
     },
     resolveContextUrl: function(requestId) {
         var contextTemplate = hudScriptElement.getAttribute('data-context-template');


### PR DESCRIPTION
For issue #16 and https://github.com/Glimpse/Glimpse.Node/pull/772

This PR provides a more robust solution to URI templating, by introducing the (tiny) `uri-templates` library that correctly parses URI templates. This also addresses the TODO:

> TODO: This should probably be resolved with a URI Template library