### PR TITLE
Removing encodeUriComponent call to prevent double encoding

### DIFF
--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -33,7 +33,7 @@ module.exports = {
         return clientTemplate.fill({
             requestId: requestId,
             follow: follow,
-            metadataUri: encodeURIComponent(hudScriptElement.getAttribute('data-metadata-template')),
+            metadataUri: hudScriptElement.getAttribute('data-metadata-template'),
         });
     },
     resolveContextUrl: function(requestId) {


### PR DESCRIPTION
Fixes #22 

This PR simply removes the call to `encodeUriComponent` inside a template created from `UriTemplate`, which internally encodes URI components already.