### PR TITLE
Added bind check

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ var zip = require('gulp-zip');
 
 var settings = {
     index: __dirname + '/src/index.html',
-    entry: __dirname + '/src/index.js',
+    entry: __dirname + '/src/bootstrap.js',
     output: __dirname + '/dist',
     server: __dirname + '/dist',
     assets: __dirname + '/assets/**/*'

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,0 +1,3 @@
+if (Function.prototype.bind) {
+    require('./index.js');
+}


### PR DESCRIPTION
This turned out to be simpler to fix than the browser agent: IE8 (and 9 apparently? I thought it supported all of ES5) don't support function.bind, but that's the only thing that was causing issues.

This creates a tiny bootstrap that bails if bind doesn't exist.

On IE8:

![screen shot 2017-03-10 at 12 36 59 pm](https://cloud.githubusercontent.com/assets/1141386/23812775/cb27f71e-0590-11e7-9eed-74867608f270.png)

On IE9:

![screen shot 2017-03-10 at 12 44 59 pm](https://cloud.githubusercontent.com/assets/1141386/23812780/cff3f522-0590-11e7-8396-a358650ad7ac.png)

On IE10:

![screen shot 2017-03-10 at 12 48 04 pm](https://cloud.githubusercontent.com/assets/1141386/23812788/d5a30d3c-0590-11e7-96bd-6a6e4495e030.png)
