### PR TITLE
updating HUD CI build to attach dev & prod archives to release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/dist/
+/.dist/
+/.archive/
 /node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,15 @@ install:
 - npm install
 - typings install
 script:
-- gulp ci
+- gulp clean
+- gulp archive-dev
+- gulp archive-prod
 deploy:
   provider: releases
   api_key:
     secure: G8FGj5OKTeieZEV1Pod1FXYq2lgEN75pHtxP9KW8C/LFzPPXJt0VJFFjKo+y+eKs5DF1+PypVAqYsGQN2cOq/ywCN34KZBLDagZ01BAvTEQKb0/JRhku3Fr7qQ+eI+HGpO2ke6AiI1tiMZc3glV96sZ4o/seZs+N6a2SceeldL3iw+lDGrUNsQlfz/yZGCLtSbiZHhDYwEwniLzd7rAYmeXZmib3kua+knEiYtJ0Sm7ylnUu3iCLRosjBfz6n0s/RrQmqZka4AONXt2ApJ4iB3bJoSvSmu+v3r1ymFwjta7x7RcfvAV4h01RfjocGblWjvwqBmKpjPB0Zt0RXDs+RwjDgxJ+bTzLUKP9pBBeATS866wjt1HBybKI8eUIJNS5tq/ALHTnh8eQ/YGAgZoeozR4g6PFIuVXlRJFL+fTpbBxSgbS/+WdCbmum/9Jgu1rWgTauOXAV1dZgswFENtqzjIKGqgnPeLivUya8cot7ug1RG2cyBg4gs76h3iG4XqZZLeN9XX9e3THxT0eJ/mGnuhtENgljkwhL63l51o3aVm/up5Ph4FwWhE+cGyUnUceN6LTgiJWh/m8frzOVykElyFfgbF22BfDoyD8Whkgh2h8BTe/rNXlLcAmiN3BCdN2GlfydRrWNlRZgi5OaSZo24XIjlRb84m5uAUt3NbDlGY=
   file: 
-  - dist/hud.zip
+  - .archive/prod/hud.zip
+  - .archive/dev/hud-dev.zip
   on:
     tags: true

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp": "^3.9.1",
     "gulp-if": "2.0.2",
     "gulp-minify-html": "1.0.6",
+    "gulp-rename": "^1.2.2",
     "gulp-util": "3.0.8",
     "gulp-zip": "^4.0.0",
     "imports-loader": "0.7.1",


### PR DESCRIPTION
 - updated travis to build both dev build & prod builds
 - updated HUD build to use `.dist` and `.archive` directories, similiar to what we're doing with browser agent & client
 - updated travis to attach hud.zip (prod archive) and hud-dev.zip (dev archive) to the release. 