### PR TITLE
Use link cursor even for Glimpse HUD sections

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -98,7 +98,6 @@ $hud-height: 40px;
     transition: all 0.3s ease;
     border: none;
     position: relative;
-    cursor: default;
     height: 37px;
 }
 .glimpse .glimpse-hud-title { 

--- a/src/index.scss
+++ b/src/index.scss
@@ -10,6 +10,7 @@
 }
 
 $hud-height: 40px;
+$hud-highlight: rgba(#0d5c9d, 0.85);
 
 .glimpse, .glimpse *, .glimpse a, .glimpse td, .glimpse th, .glimpse table {
     font-family: 'Segoe UI', 'Selawik', Tahoma, Geneva, Verdana, sans-serif;
@@ -38,16 +39,15 @@ $hud-height: 40px;
     line-height: $hud-height;
     padding: 0 1rem;
     border-right: 1px solid #3399ff;
+}
+.glimpse:hover .glimpse-link {
+    background-color: $hud-highlight;
 
-    &:hover {
-        background-color: rgba(#0d5c9d, 0.85);
-
-        > .glimpse-link-text {
-            color: #f1f1f1;
-        }
-        > .glimpse-arrow {
-            fill: #f1f1f1;
-        }
+    > .glimpse-link-text {
+        color: #f1f1f1;
+    }
+    > .glimpse-arrow {
+        fill: #f1f1f1;
     }
 }
 .glimpse .glimpse-link-text {
@@ -92,6 +92,9 @@ $hud-height: 40px;
 .glimpse .glimpse-hud { 
     display: inline-block;
     height: $hud-height;
+}
+.glimpse:hover .glimpse-hud { 
+    background-color: $hud-highlight;
 }
 .glimpse .glimpse-hud-section {
     float: left; 

--- a/src/index.scss
+++ b/src/index.scss
@@ -10,7 +10,8 @@
 }
 
 $hud-height: 40px;
-$hud-highlight: rgba(#0d5c9d, 0.85);
+$hud-highlight-background: rgba(#0d5c9d, 0.85);
+$hud-highlight-foreground: #f1f1f1;
 
 .glimpse, .glimpse *, .glimpse a, .glimpse td, .glimpse th, .glimpse table {
     font-family: 'Segoe UI', 'Selawik', Tahoma, Geneva, Verdana, sans-serif;
@@ -41,13 +42,13 @@ $hud-highlight: rgba(#0d5c9d, 0.85);
     border-right: 1px solid #3399ff;
 }
 .glimpse:hover .glimpse-link {
-    background-color: $hud-highlight;
+    background-color: $hud-highlight-background;
 
     > .glimpse-link-text {
-        color: #f1f1f1;
+        color: $hud-highlight-foreground;
     }
     > .glimpse-arrow {
-        fill: #f1f1f1;
+        fill: $hud-highlight-foreground;
     }
 }
 .glimpse .glimpse-link-text {
@@ -94,7 +95,10 @@ $hud-highlight: rgba(#0d5c9d, 0.85);
     height: $hud-height;
 }
 .glimpse:hover .glimpse-hud { 
-    background-color: $hud-highlight;
+    background-color: $hud-highlight-background;
+}
+.glimpse:hover .glimpse-hud-header, .glimpse:hover .glimpse-hud-postfix { 
+    color: $hud-highlight-foreground;
 }
 .glimpse .glimpse-hud-section {
     float: left; 


### PR DESCRIPTION
Changes the styling of the statistics section of the HUD to use the same mouse cursor and background as the "open Glimpse" section, as they both open the client.

![halfandhalfhover2](https://cloud.githubusercontent.com/assets/6402946/24779378/ddf71a46-1ae4-11e7-9f29-1bf6bf9953b3.gif)

Associated with #40.