### PR TITLE
More style changes, delay, and content type

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -76,13 +76,13 @@ $popup-delay: .3s;
     bottom: 0 !important;
     transform: translateY(calc(100% - #{$hud-height + $border-height})) !important;
     transition:
-        transform .3s ease-out,
-        z-index 0s step-end !important;
+        transform .3s $popup-delay ease-out,
+        z-index 0s $popup-delay step-end !important;
     z-index: 0;
 
     > * {
         opacity: 0 !important;
-        transition: opacity 0.3s !important;
+        transition: opacity 0.3s $popup-delay !important;
     }
 }
 .glimpse-hud-data {
@@ -93,7 +93,7 @@ $popup-delay: .3s;
 
     > :not(.glimpse-hud-popup) {
         z-index: 1 !important;
-        transition: all 0.3s !important;
+        transition: all 0.3s $popup-delay !important;
     }
 
     > .glimpse-section {
@@ -101,22 +101,18 @@ $popup-delay: .3s;
     }
 
     &:hover {
-        transition-delay: $popup-delay !important;
         border-color: transparent;
 
         > :not(.glimpse-hud-popup) {
-            transition-delay: $popup-delay !important;
             opacity: 0 !important;
         }
     }
 
     &:hover > .glimpse-hud-popup {
-        transition-delay: $popup-delay !important;
         transform: translateY(0) !important;
         z-index: 2 !important;
 
         > * {
-            transition-delay: $popup-delay !important;
             opacity: 1 !important;
         }
     }

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,10 +5,10 @@ $color-border: #999;
 $type-scales: (
     -1: 11px,
     0: 14px,
-    1: 18px,
+    1: 17px,
 );
 $border-height: 3px;
-$popup-delay: 1s;
+$popup-delay: .3s;
 
 @function type-scale($level) {
     @return map-get($type-scales, $level);
@@ -185,7 +185,7 @@ $popup-delay: 1s;
 .glimpse-time-ms,
 .glimpse-size-kb {
     &:after {
-        margin-left: 2px !important;
+        font-weight: normal !important;
     }
 }
 .glimpse-time-ms {
@@ -272,6 +272,7 @@ $popup-delay: 1s;
     }
     .glimpse-ajax-rows {
         width: 100% !important;
+        table-layout: fixed !important;
     }
     .glimpse-ajax-row {
         &:nth-last-child(#{$max-ajax-rows * 2}):first-child {
@@ -329,8 +330,9 @@ $popup-delay: 1s;
     position: relative !important;
 }
 .glimpse-ajax-cell {
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    white-space: nowrap !important;
+    text-overflow: ellipsis !important;
+    overflow: hidden !important;
     
     &:last-child {
         text-align: right !important;
@@ -358,6 +360,7 @@ $popup-delay: 1s;
 
     ~ * {
         border-left: 1px solid #999 !important;
+        margin-left: 5px !important;
     }
 
     &.-ajax {
@@ -409,7 +412,7 @@ $popup-delay: 1s;
     text-overflow: ellipsis;
 }
 .glimpse-hud-field-value {
-    font-size: type-scale(0) !important;
+    font-size: type-scale(1) !important;
     font-weight: bold !important;
 }
 .glimpse-anchor {

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,6 +8,7 @@ $type-scales: (
     1: 18px,
 );
 $border-height: 3px;
+$popup-delay: 1s;
 
 @function type-scale($level) {
     @return map-get($type-scales, $level);
@@ -74,7 +75,9 @@ $border-height: 3px;
     width: 100% !important;
     bottom: 0 !important;
     transform: translateY(calc(100% - #{$hud-height + $border-height})) !important;
-    transition: transform .3s ease-out !important;
+    transition:
+        transform .3s ease-out,
+        z-index 0s step-end !important;
     z-index: 0;
 
     > * {
@@ -90,7 +93,7 @@ $border-height: 3px;
 
     > :not(.glimpse-hud-popup) {
         z-index: 1 !important;
-        transition: opacity 0.3s !important;
+        transition: all 0.3s !important;
     }
 
     > .glimpse-section {
@@ -98,18 +101,22 @@ $border-height: 3px;
     }
 
     &:hover {
+        transition-delay: $popup-delay !important;
         border-color: transparent;
 
         > :not(.glimpse-hud-popup) {
+            transition-delay: $popup-delay !important;
             opacity: 0 !important;
         }
     }
 
     &:hover > .glimpse-hud-popup {
+        transition-delay: $popup-delay !important;
         transform: translateY(0) !important;
         z-index: 2 !important;
 
         > * {
+            transition-delay: $popup-delay !important;
             opacity: 1 !important;
         }
     }
@@ -277,6 +284,13 @@ $border-height: 3px;
             animation: glimpse-popup-ajax-row-enter .3s .3s ease-out both !important;
         }
 
+        &:nth-child(2n - 1) > .glimpse-ajax-cell {
+            padding-top: 4px !important;
+        }
+        &:nth-child(2n) > .glimpse-ajax-cell {
+            padding-bottom: 4px !important;
+        }
+
         @keyframes glimpse-popup-ajax-row-enter {
             from {
                 opacity: 0;
@@ -303,12 +317,21 @@ $border-height: 3px;
             text-align: right !important;
         }
     }
+
+    .glimpse-ajax-cell {
+        &[data-glimpse-type="content-type"] {
+            text-align: right !important;
+        }
+    }
 }
 .glimpse-ajax-row {
     white-space: nowrap !important;
     position: relative !important;
 }
 .glimpse-ajax-cell {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    
     &:last-child {
         text-align: right !important;
     }
@@ -388,4 +411,8 @@ $border-height: 3px;
 .glimpse-hud-field-value {
     font-size: type-scale(0) !important;
     font-weight: bold !important;
+}
+.glimpse-anchor {
+    color: $color-primary !important;
+    text-decoration: none !important;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -261,6 +261,9 @@ $popup-delay: .3s;
             }
         }
     }
+    .glimpse-hud-field-value {
+        font-size: type-scale(1) !important;
+    }
 }
 .glimpse-hud-popup-section {
     .glimpse-hud-field + * {
@@ -312,6 +315,12 @@ $popup-delay: .3s;
         &[data-glimpse-type="duration"],
         &[data-glimpse-type="size"] {
             text-align: right !important;
+        }
+    }
+
+    .glimpse-ajax-cell-heading {
+        &[data-glimpse-type="method"] {
+            width: 8ch !important;
         }
     }
 
@@ -408,7 +417,6 @@ $popup-delay: .3s;
     text-overflow: ellipsis;
 }
 .glimpse-hud-field-value {
-    font-size: type-scale(1) !important;
     font-weight: bold !important;
 }
 .glimpse-anchor {

--- a/src/views/ajax.js
+++ b/src/views/ajax.js
@@ -153,8 +153,8 @@ module.exports = {
                 <table class="glimpse-ajax-rows">
                     <thead>
                         <tr>
-                            <th></th>
-                            <th></th>
+                            <th class="glimpse-ajax-cell-heading" data-glimpse-type="method"></th>
+                            <th class="glimpse-ajax-cell-heading" data-glimpse-type="status"></th>
                             <th class="glimpse-ajax-cell-heading" data-glimpse-type="duration">
                                 Duration
                             </th>

--- a/src/views/ajax.js
+++ b/src/views/ajax.js
@@ -26,7 +26,7 @@ const state = {
 };
 
 function processContentType(type) {
-    return type ? type.substring(0, type.indexOf(';')) : '--';
+    return type || '--';
 };
 function processSize(size) {
     return size ? (Math.round((size / 1024) * 10) / 10) : '--';
@@ -53,7 +53,7 @@ function rowPopupTemplate(request) {
     return `
         <tr class="glimpse-ajax-row">
             <td class="glimpse-ajax-cell" title="${request.uri}" colspan="2">
-                <a href="${url}" target="_glimpse">${request.uri}</a>
+                <a class="glimpse-anchor" href="${url}" target="_glimpse">${request.uri}</a>
             </td>
             <td class="glimpse-ajax-cell glimpse-time-ms" data-glimpse-type="duration">
                 ${request.duration}
@@ -63,10 +63,10 @@ function rowPopupTemplate(request) {
             </td>
         </tr>
         <tr class="glimpse-ajax-row">
-            <td class="glimpse-ajax-cell glimpse-label">${request.method}</td>
-            <td class="glimpse-ajax-cell">${request.status} - ${request.statusText}</td>
-            <td class="glimpse-ajax-cell" title="${request.contentType}">${processContentType(request.contentType)}</td>
-            <td class="glimpse-ajax-cell">${request.time.toTimeString().replace(/.*(\d{2}:\d{2}:\d{2}).*/, '$1')}</td>
+            <td class="glimpse-ajax-cell glimpse-label" data-glimpse-type="method">${request.method}</td>
+            <td class="glimpse-ajax-cell" data-glimpse-type="status">${request.status} - ${request.statusText}</td>
+            <td class="glimpse-ajax-cell" title="${request.contentType}" data-glimpse-type="content-type">${processContentType(request.contentType)}</td>
+            <td class="glimpse-ajax-cell" data-glimpse-type="time">${request.time.toTimeString().replace(/.*(\d{2}:\d{2}:\d{2}).*/, '$1')}</td>
         </tr>
     `;
 }

--- a/src/views/timing.js
+++ b/src/views/timing.js
@@ -6,12 +6,14 @@ module.exports = {
 
         return `
             <div class="glimpse-section glimpse-timing">
-                <div class="glimpse-hud-field">
-                    <div class="glimpse-hud-field-label">
-                        Page load time
-                    </div>
-                    <div class="glimpse-hud-field-value glimpse-time-ms">
-                        ${timings.pageLoad}
+                <div class="glimpse-section-summary">
+                    <div class="glimpse-hud-field">
+                        <div class="glimpse-hud-field-label">
+                            Page load time
+                        </div>
+                        <div class="glimpse-hud-field-value glimpse-time-ms">
+                            ${timings.pageLoad}
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Addressing comments here: https://github.com/Glimpse/Glimpse.Client.Hud/pull/109#issuecomment-307890492

> Looking great! Looks like content type is missing? Does the URL, status test and content type (when added) overflow correctly. Also if we could add a little more space between request items in the ajax list and could we get a little more margin space to the left of the dividing line... thinking about it having a bit more of a sense of space. Also are you planning on adding the mouse over delay in this PR?

![jun-19-2017 18-13-25](https://user-images.githubusercontent.com/1093738/27308182-4e0d3192-551b-11e7-9de8-4e661dd26574.gif)
