### PR TITLE
[Data] Add summary details

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -388,6 +388,21 @@ $popup-delay: .3s;
     .glimpse-hud-field-value {
         white-space: nowrap !important;
     }
+    .glimpse-hud-field-listing {
+        padding-bottom: 5px;
+        padding-top: 2px;
+        opacity: 0.5;
+        span {
+            font-size: 10px !important;
+            white-space: nowrap !important;
+            padding-right: 5px;
+            float: left;
+            padding-top: 1px;
+        }
+        div {
+            clear: both;
+        }
+    }
     > .glimpse-hud-field {
         margin: 0 !important;
         padding: 5px 0 0 10px !important;

--- a/src/views/data.js
+++ b/src/views/data.js
@@ -1,6 +1,9 @@
 const dom = require('../lib/dom');
 const summaryRepository = require('../repository/summary');
 
+const supportedStatusCodes = [ '200', '400', '500' ];
+const supportedOperationCategories = [ 'Create', 'Read', 'Update', 'Delete', 'Other' ];
+
 function processType(summary) {
     return {
         total: summary.totalCount,
@@ -8,13 +11,38 @@ function processType(summary) {
     };
 }
 function process(requestSummary) {
+    const webServicesData = requestSummary.summary.server.webServices;
+    const dataStoreData = requestSummary.summary.server.dataStore;
+
+    // summary
     const result = {};
-    result.webServices = processType(requestSummary.summary.server.webServices);
-    result.dataStore = processType(requestSummary.summary.server.dataStore);
+    result.webServices = processType(webServicesData);
+    result.dataStore = processType(dataStoreData);
     result.summary = {
         total: result.webServices.total + result.dataStore.total,
         time: result.webServices.time + result.dataStore.time
     };
+
+    // web services
+    const statusCodes = result.webServices.statusCodes = {};
+    webServicesData.listing.forEach(function(item) {
+        const statusCodeGroup = (parseInt(item.statusCode / 100) * 100).toString();
+        if (!statusCodes[statusCodeGroup]) {
+            statusCodes[statusCodeGroup] = 0;
+        }
+        statusCodes[statusCodeGroup]++;
+    });
+
+    // data store
+    const operationCategories = result.dataStore.operationCategories = {};
+    dataStoreData.listing.forEach(function(item) {
+        const operationCategory = item.operationCategory.toLowerCase();
+        if (!operationCategories[operationCategory]) {
+            operationCategories[operationCategory] = 0;
+        }
+        operationCategories[operationCategory]++;
+    });
+
     return result;
 }
 
@@ -23,17 +51,54 @@ function update(model) {
     updateValue('glimpse-data-popup-summary-value', model.summary);
     updateValue('glimpse-data-popup-webServices-value', model.webServices);
     updateValue('glimpse-data-popup-dataStore-value', model.dataStore);
+
+    updateListingWebServices('glimpse-data-popup-webServices-subvalue', model.webServices.statusCodes);
+    updateListingDataStore('glimpse-data-popup-dataStore-subvalue', model.dataStore.operationCategories);
 }
-function updateValue(target, model) {
+function updateValue(target, summary) {
     const element = document.getElementById(target);
 
-    let content = model.total;
-    if (model.total > 0) {
+    let content = summary.total;
+    if (summary.total > 0) {
         dom.addClass(element, 'glimpse-time-ms');
 
-        content += ' / ' + model.time;
+        content += ' / ' + summary.time;
     }
     element.innerHTML = content;
+}
+function updateListingWebServices(target, statusCodes) {
+    updateCoreListing(target, Object.assign({}, statusCodes), supportedStatusCodes, 's');
+}
+function updateListingDataStore(target, operationCategories) {
+    updateCoreListing(target, Object.assign({}, operationCategories), supportedOperationCategories, '');
+}
+function updateCoreListing(target, data, supportedRecords, postfix) {
+    // run through supported status codes so order is maintained
+    let content = '';
+    supportedRecords.forEach(function(record) {
+        const recordLower = record.toLowerCase();
+        if (data[recordLower]) {
+            content += '<span>' + record + postfix + ' (' + data[recordLower] + ')</span>';
+            delete data[recordLower];
+        }
+    });
+
+    // process the remaining items
+    let otherCount = 0;
+    Object.keys(data).forEach(function(key) {
+        otherCount += data[key];
+    });
+    if (otherCount > 0) {
+        content += '<span>Others (' + otherCount + ')</span>';
+    }
+
+    const targetElement = document.getElementById(target);
+    if (content.length > 0) {
+        targetElement.innerHTML = content + '<div></div>';
+    }
+    else {
+        targetElement.remove();
+    }
 }
 
 module.exports = {
@@ -76,12 +141,14 @@ module.exports = {
                         <div class="glimpse-hud-field-value" id="glimpse-data-popup-webServices-value">
                             --
                         </div>
+                        <div class="glimpse-hud-field-listing" id="glimpse-data-popup-webServices-subvalue"></div>
                     </div>
                     <div class="glimpse-hud-field">
                         <div class="glimpse-hud-field-label">Data acces</div>
                         <div class="glimpse-hud-field-value" id="glimpse-data-popup-dataStore-value">
                             --
                         </div>
+                        <div class="glimpse-hud-field-listing" id="glimpse-data-popup-dataStore-subvalue"></div>
                     </div>
                 </div>
             </div>

--- a/src/views/data.js
+++ b/src/views/data.js
@@ -84,10 +84,9 @@ function updateCoreListing(target, data, supportedRecords, postfix) {
     });
 
     // process the remaining items
-    let otherCount = 0;
-    Object.keys(data).forEach(function(key) {
-        otherCount += data[key];
-    });
+    const otherCount = Object.keys(data)
+        .reduce((acc, key) => acc + data[key], 0);
+
     if (otherCount > 0) {
         content += '<span>Others (' + otherCount + ')</span>';
     }


### PR DESCRIPTION
<img width="802" alt="screen shot 2017-06-26 at 7 44 36 am" src="https://user-images.githubusercontent.com/585619/27544904-5f66e758-5a43-11e7-93e0-dfb1df257b8c.png">

<img width="793" alt="screen shot 2017-06-26 at 7 44 14 am" src="https://user-images.githubusercontent.com/585619/27544913-652f7272-5a43-11e7-9850-1e275f959484.png">

This adds summary details to each of the data sections. Note that we will only show `200`s, `400`s and `500`s in the web service section, all other status codes will be grouped under other.