### PR TITLE
Refactoring AJAX row layout

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -269,71 +269,29 @@ $popup-delay: 0s;
     }
     .glimpse-ajax-rows {
         width: 100% !important;
-        table-layout: fixed !important;
-        &.glimpse-ajax-rows--hidden {
-            display: none;
-        }
     }
     .glimpse-ajax-row {
-        &:nth-last-child(#{$max-ajax-rows * 2}):first-child {
-            &, & ~ * {
-                animation: glimpse-popup-ajax-row-move .3s ease-out both !important;
-            }
-        }
-
-        &:last-child, &:nth-last-child(2) {
-            animation: glimpse-popup-ajax-row-enter .3s .3s ease-out both !important;
-        }
-
-        &:nth-child(2n - 1) > .glimpse-ajax-cell {
-            padding-top: 4px !important;
-        }
-        &:nth-child(2n) > .glimpse-ajax-cell {
-            padding-bottom: 4px !important;
-        }
-
-        @keyframes glimpse-popup-ajax-row-enter {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes glimpse-popup-ajax-row-move {
-            from {
-                transform: translateY(200%);
-            }
-            to {
-                transform: translateY(0);
-            }
-        }
-    }
-
-    .glimpse-ajax-cell,
-    .glimpse-ajax-cell-heading {
-        &[data-glimpse-type="duration"],
-        &[data-glimpse-type="size"] {
-            text-align: right !important;
-        }
-    }
-
-    .glimpse-ajax-cell-heading {
-        &[data-glimpse-type="method"] {
-            width: 8ch !important;
-        }
-    }
-
-    .glimpse-ajax-cell {
-        &[data-glimpse-type="content-type"] {
-            text-align: right !important;
-        }
+        margin-bottom: 5px !important;
     }
 }
 .glimpse-ajax-row {
     white-space: nowrap !important;
     position: relative !important;
+}
+.glimpse-ajax-row-line {
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    display: flex !important;
+    flex-direction: row !important;
+    justify-content: flex-start !important;
+    align-items: center !important;
+    height: type-scale(1) !important;
+    font-size: type-scale(0) !important;
+
+    &--secondary {
+        font-size: type-scale(-1) !important;
+    }
 }
 .glimpse-ajax-cell {
     white-space: nowrap !important;
@@ -342,6 +300,16 @@ $popup-delay: 0s;
     
     &:last-child {
         text-align: right !important;
+    }
+}
+.glimpse-ajax-text {
+    &[data-glimpse-type="uri"],
+    &[data-glimpse-type="status"] {
+        flex-grow: 1;
+    }
+
+    + .glimpse-ajax-text {
+        margin-left: 5px !important;
     }
 }
 .glimpse-ajax-uri {
@@ -475,4 +443,10 @@ $popup-delay: 0s;
             fill: #1ba1e2 !important;
         }
     }
+}
+
+#glimpse-ajax-popup-rows {
+    height: 150px !important;
+    max-height: 150px !important;
+    overflow-y: auto !important;
 }

--- a/src/views/ajax.js
+++ b/src/views/ajax.js
@@ -22,7 +22,7 @@ const state = {
         timeout: undefined,
         stack: [],
         template: rowPopupTemplate,
-        length: -3
+        length: 0
     }
 };
 
@@ -54,32 +54,37 @@ function rowPopupTemplate(request) {
     const url = util.resolveClientUrl(request.requestId, false);
 
     return `
-        <tr class="glimpse-ajax-row">
-            <td class="glimpse-ajax-cell" title="${request.uri}" colspan="2">
-                <a class="glimpse-anchor" href="${url}" target="_glimpse" title="Open '${request.uri}' in Glimpse">${arrowIcon}</a> ${request.uri}
-            </td>
-            <td class="glimpse-ajax-cell glimpse-time-ms" data-glimpse-type="duration">
-                ${request.duration}
-            </td>
-            <td class="glimpse-ajax-cell glimpse-size-kb" data-glimpse-type="size">
-                ${processSize(request.size)}
-            </td>
-        </tr>
-        <tr class="glimpse-ajax-row">
-            <td class="glimpse-ajax-cell glimpse-label" data-glimpse-type="method">${request.method}</td>
-            <td class="glimpse-ajax-cell" data-glimpse-type="status">${request.status} - ${request.statusText}</td>
-            <td class="glimpse-ajax-cell" title="${request.contentType}" data-glimpse-type="content-type">${processContentType(request.contentType)}</td>
-            <td class="glimpse-ajax-cell" data-glimpse-type="time">${request.time
-                .toTimeString()
-                .replace(/.*(\d{2}:\d{2}:\d{2}).*/, '$1')}</td>
-        </tr>
+        <div class="glimpse-ajax-row">
+            <div class="glimpse-ajax-row-line">
+                <span class="glimpse-ajax-text" data-glimpse-type="uri" title="${request.uri}">
+                    <a class="glimpse-anchor" href="${url}" target="_glimpse" title="Open '${request.uri}' in Glimpse">${arrowIcon}</a> ${request.uri}
+                </span>
+                <span class="glimpse-ajax-text" data-glimpse-type="time">
+                    ${request.time
+                        .toTimeString()
+                        .replace(/.*(\d{2}:\d{2}:\d{2}).*/, '$1')}
+                </span>
+            </div>
+            <div class="glimpse-ajax-row-line glimpse-ajax-row-line--secondary">
+                <span class="glimpse-ajax-text glimpse-label" data-glimpse-type="method">
+                    ${request.method}
+                </span>
+                <span class="glimpse-ajax-text" data-glimpse-type="status">
+                    ${request.status} - ${request.statusText}
+                </span>
+                <span class="glimpse-ajax-text glimpse-size-kb" data-glimpse-type="size">
+                    ${processSize(request.size)}
+                </span>
+                <span class="glimpse-ajax-text glimpse-time-ms" data-glimpse-type="duration">
+                    ${request.duration}
+                </span>
+            </div>
+        </div>
     `;
 }
 
 function update(request) {
     state.count++;
-
-    dom.removeClass(document.getElementById('glimpse-ajax-popup-list'), 'glimpse-ajax-rows--hidden');
 
     updateCounter(state.summary, state.count);
     updateCounter(state.popup, state.count);
@@ -104,6 +109,7 @@ function updateView(details, request) {
         .concat(request);
     document.getElementById(details.rowsId).innerHTML = details.stack
         .map(details.template)
+        .reverse()
         .join('\n');
 }
 
@@ -157,22 +163,8 @@ module.exports = {
                         ${state.count}
                     </div>
                 </div>
-                <table class="glimpse-ajax-rows glimpse-ajax-rows--hidden" id="glimpse-ajax-popup-list">
-                    <thead>
-                        <tr>
-                            <th class="glimpse-ajax-cell-heading" data-glimpse-type="method"></th>
-                            <th class="glimpse-ajax-cell-heading" data-glimpse-type="status"></th>
-                            <th class="glimpse-ajax-cell-heading" data-glimpse-type="duration">
-                                Duration
-                            </th>
-                            <th class="glimpse-ajax-cell-heading" data-glimpse-type="size">
-                                Size
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody id="glimpse-ajax-popup-rows">
-                    </tbody>
-                </table>
+                <div id="glimpse-ajax-popup-rows">
+                </div>
             </div>
         `;
     }


### PR DESCRIPTION
This PR addresses these issues:

Browser calls layout - requests to look like the history list in the client:
- We don’t need to worry about the https icon or the browser icon,
- the 1st like should look something like   `{url}                                              {time}`
- the 2nd line should look something like `{method} {statusIcon} {statusCode}      {size} {duration}`
- We should still keep the header that says “Size” and duration “Duration”
  - ⚠️ Note: this is not present in this PR


Browser calls transitions - items need to load from the top not the bottom
- The idea is for it to be the same as the request history list, hence loading from the top
- Note the animation/transition should make it obvious that a new item has loaded
  - ⚠️ Note: right now it is a jump-cut immediate transition, just like the Glimpse Client. Can be refined later

Browser calls length - number of requests that we show shouldn’t be limited in the popup
- At the moment we limit the number of items we show to 4… this should be changed so that we show all
- Note the container the list is in should have a max height and a scrollbar should appear on overflow

<img width="749" alt="screen shot 2017-06-26 at 2 41 16 pm" src="https://user-images.githubusercontent.com/1093738/27554815-bbaf284c-5a7d-11e7-8af4-a57e780a5b59.png">
