### PR TITLE
[hud expand button]: fix expand state icon

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -462,6 +462,7 @@ $collapseHoverColor: #353535;
 
     $iconSize: 8px;
     .icon-arrow {
+        display: block;
         width: $iconSize !important;
         height: $iconSize !important;
         margin-left: -$iconSize/2 !important;

--- a/src/views/expand-button-view.js
+++ b/src/views/expand-button-view.js
@@ -10,7 +10,7 @@ module.exports = {
     },
     renderPopup: function() {
         return `
-            <div class="glimpse-hud-popup-section glimpse-hud-popup-section--expandArrow" id="js-glimpse-collapse-button" title="collapse">
+            <div class="glimpse-hud-popup-section glimpse-hud-popup-section--arrow" id="js-glimpse-collapse-button" title="collapse">
               ${icons.expandArrow}
             </div>
         `;


### PR DESCRIPTION
Issue: https://github.com/Glimpse/Glimpse.Client.Hud/issues/137

PR fixes the icon appeareance for the expand state of toggle button.

![image](https://user-images.githubusercontent.com/1478800/27613598-f6c389d4-5b61-11e7-9d27-e86efec59b80.png)
