### PR TITLE
Fixing scrollbar spacing issue

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -447,6 +447,7 @@ $collapseHoverColor: #353535;
     max-height: 150px !important;
     width: 220px !important;
     overflow-y: auto !important;
+    padding-right: 5px !important;
 }
 
 .glimpse-hud-field-listing {


### PR DESCRIPTION
For #138. This adds a 5px padding so that the content does not touch the Windows scroll bars.
![2jfij239ifj29ifasd](https://user-images.githubusercontent.com/1093738/27651944-d529d098-5bee-11e7-8a90-51c68f69c546.PNG)

