### PR TITLE
[ajax browser calls section]: add `ellipsis` to the long URLs

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -285,6 +285,11 @@ $collapseHoverColor: #353535;
     &:last-child {
         text-align: right !important;
     }
+
+    &--duration {
+      text-overflow: none !important;
+      overflow: visible !important;
+    }
 }
 .glimpse-ajax-text {
     &--uri {

--- a/src/index.scss
+++ b/src/index.scss
@@ -287,11 +287,27 @@ $collapseHoverColor: #353535;
     }
 }
 .glimpse-ajax-text {
+    &--uri {
+      width: 100%;
+      display: inline-block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      box-sizing: border-box;
+      padding-right: 1.2rem;
+      vertical-align: bottom;
+    }
+
     &[data-glimpse-type="uri"],
     &[data-glimpse-type="status"] {
         flex-grow: 1 !important;
         white-space: nowrap !important;
         text-overflow: ellipsis !important;
+    }
+
+    &[data-glimpse-type="uri"] {
+      width: 50%;
+      display: inline-block;
     }
 
     &[data-glimpse-type="status"] {

--- a/src/index.scss
+++ b/src/index.scss
@@ -62,7 +62,7 @@ $collapseHoverColor: #353535;
     transition:
         transform .3s ease-out,
         z-index 0s step-end,
-        opacity 0s .3s step-end  !important;
+        opacity 0s .3s step-end !important;
     z-index: 0;
 
     > * {
@@ -288,14 +288,14 @@ $collapseHoverColor: #353535;
 }
 .glimpse-ajax-text {
     &--uri {
-      width: 100%;
-      display: inline-block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      box-sizing: border-box;
-      padding-right: 1.2rem;
-      vertical-align: bottom;
+      width: 100% !important;
+      display: inline-block !important;
+      overflow: hidden !important;
+      text-overflow: ellipsis !important;
+      white-space: nowrap !important;
+      box-sizing: border-box !important;
+      padding-right: 1.2rem !important;
+      vertical-align: bottom !important;
     }
 
     &[data-glimpse-type="uri"],
@@ -306,8 +306,8 @@ $collapseHoverColor: #353535;
     }
 
     &[data-glimpse-type="uri"] {
-      width: 50%;
-      display: inline-block;
+      width: 50% !important;
+      display: inline-block !important;
     }
 
     &[data-glimpse-type="status"] {

--- a/src/index.scss
+++ b/src/index.scss
@@ -286,7 +286,7 @@ $collapseHoverColor: #353535;
         text-align: right !important;
     }
 
-    &--duration {
+    &[data-glimpse-type="duration"] {
       text-overflow: none !important;
       overflow: visible !important;
     }

--- a/src/views/ajax.js
+++ b/src/views/ajax.js
@@ -58,7 +58,10 @@ function rowPopupTemplate(request) {
         <div class="glimpse-ajax-row">
             <div class="glimpse-ajax-row-line">
                 <span class="glimpse-ajax-text" data-glimpse-type="uri" title="${request.uri}">
-                    <a class="glimpse-anchor" href="${url}" target="_glimpse" title="Open '${request.uri}' in Glimpse">${arrowIcon}</a> ${request.uri}
+                    <a class="glimpse-anchor" href="${url}" target="_glimpse" title="Open '${request.uri}' in Glimpse">${arrowIcon}</a>
+                    <span class="glimpse-ajax-text glimpse-ajax-text--uri" title="${request.uri}">
+                        ${request.uri}
+                    </span>
                 </span>
                 <span class="glimpse-ajax-text" data-glimpse-type="time">
                     ${request.time

--- a/src/views/ajax.js
+++ b/src/views/ajax.js
@@ -45,7 +45,7 @@ function rowTemplate(request) {
             <td class="glimpse-ajax-cell glimpse-ajax-uri" title="${request.uri}">
                 <a class="glimpse-anchor" href="${url}" target="_glimpse" title="Open '${request.uri}' in Glimpse">${arrowIcon}</a> ${request.uri}
             </td>
-            <td class="glimpse-ajax-cell" data-glimpse-type="duration">
+            <td class="glimpse-ajax-cell glimpse-ajax-cell--duration" data-glimpse-type="duration">
                 <span class="glimpse-time-ms">${request.duration}</span>
             </td>
         </tr>

--- a/src/views/ajax.js
+++ b/src/views/ajax.js
@@ -45,7 +45,7 @@ function rowTemplate(request) {
             <td class="glimpse-ajax-cell glimpse-ajax-uri" title="${request.uri}">
                 <a class="glimpse-anchor" href="${url}" target="_glimpse" title="Open '${request.uri}' in Glimpse">${arrowIcon}</a> ${request.uri}
             </td>
-            <td class="glimpse-ajax-cell glimpse-ajax-cell--duration" data-glimpse-type="duration">
+            <td class="glimpse-ajax-cell" data-glimpse-type="duration">
                 <span class="glimpse-time-ms">${request.duration}</span>
             </td>
         </tr>


### PR DESCRIPTION
PR adds ellipsis to long URLs in `Browser calls` section.

![image](https://user-images.githubusercontent.com/1478800/27702998-a3fc6ad4-5ccb-11e7-8595-fd304c73e4a8.png)
