### PR TITLE
Adding fetch polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "webpack": "2.2.1"
   },
   "dependencies": {
-    "uri-templates": "^0.2.0"
+    "uri-templates": "^0.2.0",
+    "whatwg-fetch": "^2.0.3"
   }
 }

--- a/src/repository/summary.js
+++ b/src/repository/summary.js
@@ -1,4 +1,5 @@
 const util = require('../lib/util');
+require('whatwg-fetch');
 
 const getPromise = fetch(util.resolveContextSummaryUrl(util.currentRequestId()))
     .then(


### PR DESCRIPTION
Adds `fetch` polyfill for older versions of Safari that don't think `fetch` is a thing.

This was probably (accidentally?) removed during the first refactor.