### PR TITLE
Fixing font smoothing for Safari

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -37,6 +37,7 @@ $collapseHoverColor: #353535;
     font-size: type-scale(0) !important;
     font-family: 'Selawik', sans-serif !important;
     font-weight: 300 !important;
+    -webkit-font-smoothing: subpixel-antialiased;
 
     > * + * {
         border-left: 1px solid $color-border !important;


### PR DESCRIPTION

**Before:**
<img width="486" alt="screen shot 2017-06-30 at 3 23 38 pm" src="https://user-images.githubusercontent.com/1093738/27751179-1a4cc6f6-5da9-11e7-87ee-1600156873dd.png">

**After:**
<img width="483" alt="screen shot 2017-06-30 at 3 23 47 pm" src="https://user-images.githubusercontent.com/1093738/27751178-1a3f4508-5da9-11e7-9e2b-32682418a3d2.png">