### PR TITLE
Adding reset styles to prevent stray styles

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -265,7 +265,10 @@ $collapseHoverColor: #353535;
 .glimpse-ajax-row {
     white-space: nowrap !important;
     position: relative !important;
-    animation: glimpse-ajax-row-enter .3s ease-out;
+    animation: glimpse-ajax-row-enter .3s ease-out !important;
+    border: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
 }
 .glimpse-ajax-row-line {
     white-space: nowrap !important;
@@ -282,6 +285,9 @@ $collapseHoverColor: #353535;
     white-space: nowrap !important;
     text-overflow: ellipsis !important;
     overflow: hidden !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    font-size: inherit !important;
 
     &:last-child {
         text-align: right !important;


### PR DESCRIPTION
Fixes #158 

<img width="788" alt="screen shot 2017-07-05 at 5 06 44 pm" src="https://user-images.githubusercontent.com/1093738/27885021-77286cb4-61a4-11e7-9ecd-4154d2dbef18.png">


This will be solved more robustly once we move to an `<iframe>`-based solution. The current infrastructure is very vulnerable to style leaks.