### PR TITLE
Preventing DOM operations on null nodes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,11 @@ function postRender(initPromise) {
     var expandButton = document.querySelector('#js-glimpse-expand-button');
     var collapseButton = document.querySelector('#js-glimpse-collapse-button');
 
+    if (!hudData) {
+        // element does not exist yet
+        return;
+    }
+
     ajaxView.postRender(initPromise);
     logsView.postRender(initPromise);
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -265,7 +265,10 @@ $collapseHoverColor: #353535;
 .glimpse-ajax-row {
     white-space: nowrap !important;
     position: relative !important;
-    animation: glimpse-ajax-row-enter .3s ease-out;
+    animation: glimpse-ajax-row-enter .3s ease-out !important;
+    border: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
 }
 .glimpse-ajax-row-line {
     white-space: nowrap !important;
@@ -282,6 +285,9 @@ $collapseHoverColor: #353535;
     white-space: nowrap !important;
     text-overflow: ellipsis !important;
     overflow: hidden !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    font-size: inherit !important;
 
     &:last-child {
         text-align: right !important;

--- a/src/index.scss
+++ b/src/index.scss
@@ -265,10 +265,7 @@ $collapseHoverColor: #353535;
 .glimpse-ajax-row {
     white-space: nowrap !important;
     position: relative !important;
-    animation: glimpse-ajax-row-enter .3s ease-out !important;
-    border: none !important;
-    padding: 0 !important;
-    margin: 0 !important;
+    animation: glimpse-ajax-row-enter .3s ease-out;
 }
 .glimpse-ajax-row-line {
     white-space: nowrap !important;
@@ -285,9 +282,6 @@ $collapseHoverColor: #353535;
     white-space: nowrap !important;
     text-overflow: ellipsis !important;
     overflow: hidden !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    font-size: inherit !important;
 
     &:last-child {
         text-align: right !important;

--- a/src/views/ajax.js
+++ b/src/views/ajax.js
@@ -99,6 +99,11 @@ function update(request) {
 }
 function updateCounter(details, count) {
     var counter = document.getElementById(details.countId);
+    if (!counter) {
+        // element does not exist yet
+        return;
+    }
+    
     counter.innerText = count;
     dom.addClass(counter, 'glimpse-section-value--update');
     if (details.timeout) {

--- a/src/views/data.js
+++ b/src/views/data.js
@@ -60,6 +60,11 @@ function update(model) {
 function updateValue(target, summary) {
     const element = document.getElementById(target);
 
+    if (!element) {
+        // element does not exist yet
+        return;
+    }
+
     let content = summary.total;
     if (summary.total > 0) {
         dom.addClass(element, 'glimpse-time-ms');
@@ -96,6 +101,11 @@ function updateCoreListing(target, data, supportedRecords, isStatusCode) {
     }
 
     const targetElement = document.getElementById(target);
+    if (!targetElement) {
+        // element does not exist yet
+        return;
+    }
+
     if (content.length > 0) {
         targetElement.innerHTML = `${content}<div></div>`;
     }


### PR DESCRIPTION
This adds some general safeguards for DOM nodes that might not exist yet, due to rendering being blocked or something related to that (see #155).

This solution is basically a patch, and will be more robustly fixed once we have an actual framework in place (React/Preact, etc).