### PR TITLE
[Version] Fix version check to not show update icon if not needed

### DIFF
--- a/src/views/version.js
+++ b/src/views/version.js
@@ -10,7 +10,8 @@ function getLatestVersion() {
     try {
         const updateInfo = JSON.parse(localStorage.getItem('glimpseLatestVersion'));
 
-        if (updateInfo.latestVersion && updateInfo.latestVersion !== updateInfo.atTimeOfCheckVersion) {
+        if (updateInfo.latestVersion
+            && updateInfo.latestVersion !== GLIMPSE_VERSION) {
             return updateInfo.latestVersion;
         }
     } catch (e) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,8 @@ module.exports = {
     plugins: [
         new webpack.DefinePlugin({
             DIAGNOSTICS: false,
-            FAKE_SERVER: false
+            FAKE_SERVER: false,
+            GLIMPSE_VERSION: JSON.stringify(require('./package.json').version)
         })
     ],
     stats: "normal"


### PR DESCRIPTION
This updates the version check logic so that it only show the version number if latest found version doesn't match the current version. This is different than the previous check which looked at the version number at time that the new version was found.